### PR TITLE
Add number field to search

### DIFF
--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -73,7 +73,7 @@ def search(request: HttpRequest) -> HttpResponse:
 
     # If the user has searched by bill number, only search the number field
     # This is to avoid returning unrelated results for bill numbers
-    if re.match(bill_number_pattern, query.strip().upper()):
+    if re.fullmatch(bill_number_pattern, query.strip().upper()):
         search_vector = SearchVector("number", config="english")
         search_query = SearchQuery(query, config="english")
         results = BillsTable.objects.annotate(search=search_vector).filter(search=search_query)

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -69,7 +69,7 @@ def search(request: HttpRequest) -> HttpResponse:
 
     results = []
 
-    bill_number_pattern = r'^(HB|HR|SJR|HJR|HJRCA|SR|SJRCA|SB|AM)\s*\d+'
+    bill_number_pattern = r'^(HB|HR|SJR|HJR|HJRCA|SR|SJRCA|SB|AM|EO|JSR)\s*\d+'
 
     # If the user has searched by bill number, only search the number field
     # This is to avoid returning unrelated results for bill numbers

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -1,3 +1,5 @@
+import re
+
 from django.contrib.auth.decorators import login_required
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from django.http import Http404, HttpRequest, HttpResponse
@@ -67,15 +69,23 @@ def search(request: HttpRequest) -> HttpResponse:
 
     results = []
 
-    if query:
-        search_vector = SearchVector("title", "summary", config="english")
-        search_query = SearchQuery(query, search_type="websearch", config="english")
+    bill_number_pattern = r'^(HB|HR|SJR|HJR|HJRCA|SR|SJRCA|SB|AM)\s*\d+'
+
+    # If the user has searched by bill number, only search the number field
+    # This is to avoid returning unrelated results for bill numbers
+    if re.match(bill_number_pattern, query.strip().upper()):
+        search_vector = SearchVector("number", config="english")
+        search_query = SearchQuery(query, config="english")
         results = BillsTable.objects.annotate(search=search_vector).filter(search=search_query)
 
-        if state:
-            results = results.filter(state=state)
-
+    else:
+        search_vector = SearchVector("title", "summary", "number", config="english")
+        search_query = SearchQuery(query, config="english")
+        results = BillsTable.objects.annotate(search=search_vector).filter(search=search_query)
         results = results.annotate(rank=SearchRank(search_vector, search_query)).order_by("-rank")
+
+    if state:
+        results = results.filter(state=state)    
 
     if request.user.is_authenticated:
         user_id = request.user.id


### PR DESCRIPTION
This pull request does the following:

* Allows users to search by bill number. If a user inputs a string matching a bill number format, the search function will only search by bill number. Otherwise, it will search title, summary, and number. This is to avoid behavior where searching for "HR 87" returns multiple bills.