### PR TITLE
Add pagination

### DIFF
--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -1,12 +1,12 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
+from django.core.paginator import Paginator
 from django.http import Http404, HttpRequest, HttpResponse
 from .models import BillsTable
 from django.db.models import Exists, OuterRef
 from django.shortcuts import get_object_or_404, redirect, render
 
 from .models import FavoritesTable
-
 
 def home(request: HttpRequest) -> HttpResponse:
     """
@@ -86,12 +86,19 @@ def search(request: HttpRequest) -> HttpResponse:
 
         results = results.annotate(favorite=Exists(favorites_query))
 
+    # Paginate the results to avoid overwhelming the frontend
+    paginator = Paginator(results, 10)
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
+
     return render(
         request,
         "search.html",
-        {"query": request.GET.get("query", ""), "results": results},
+        {
+            "query": query,
+            "results": page_obj,
+        },
     )
-
 
 @login_required
 def toggle_favorite(request, bill_id):

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 
 from .models import FavoritesTable
 
+
 def home(request: HttpRequest) -> HttpResponse:
     """
     Render the home page.
@@ -99,6 +100,7 @@ def search(request: HttpRequest) -> HttpResponse:
             "results": page_obj,
         },
     )
+
 
 @login_required
 def toggle_favorite(request, bill_id):

--- a/templates/search.html
+++ b/templates/search.html
@@ -107,6 +107,24 @@
                 {% endfor %}
               </tbody>
         </table>
+        <div class="pagination">
+          <!-- Pagination controls -->
+    <span class="step-links">
+        {% if results.has_previous %}
+            <a href="?page=1&query={{ query }}">&laquo; first</a>
+            <a href="?page={{ results.previous_page_number }}&query={{ query }}">previous</a>
+        {% endif %}
+
+        <span class="current">
+            Page {{ results.number }} of {{ results.paginator.num_pages }}.
+        </span>
+
+        {% if results.has_next %}
+            <a href="?page={{ results.next_page_number }}&query={{ query }}">next</a>
+            <a href="?page={{ results.paginator.num_pages }}&query={{ query }}">last &raquo;</a>
+        {% endif %}
+    </span>
+</div>
         {% else %}
             <p class="has-text-centered custom-text-dark">Please enter a search term.</p>
         {% endif %}


### PR DESCRIPTION
This pull request does two things:

* Adds pagination to the Django backend view, returning only 10 bills at a time. If we want, we can increase the amount of bills, but for now it's at 10.

* Adds a rough pagination template (it does not look nice), just to be able to test that the pagination view works.

Because I've edited `search.html`, i'm kicking this to frontend to review.