### PR TITLE
169 create delete account view

### DIFF
--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -4,4 +4,6 @@ from . import views
 urlpatterns = [
     path("signup/", views.make_account_page, name="signup"),
     path("unsubscribe/", views.unsubscribe, name="unsubscribe"),
+    path("delete_account/", views.delete_account, name="delete_account"),
+    path("account_goodbye/", views.account_goodbye, name="account_goodbye"),
 ]

--- a/docs/endpoints/auth.md
+++ b/docs/endpoints/auth.md
@@ -48,3 +48,15 @@ Parameters:
 * email: `str`
 
 Response: HTML password reset page, sends an email to the user upon form submit.
+
+## /accounts/delete_account
+
+Parameters:
+
+* password: `str`
+
+Response: Redirect to goodbye page on success, error message on failure
+
+## /accounts/account_goodbye
+
+Response: HTML goodbye page

--- a/templates/account/account_goodbye.html
+++ b/templates/account/account_goodbye.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html lang="en">
+    <p>Your account has been deleted.</p>
+    </html>

--- a/templates/account/delete_account.html
+++ b/templates/account/delete_account.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+    <h1>Confirm deletion</h1>
+    <form method="POST">
+        {% csrf_token %}
+        {% if messages %}
+        <div class="messages">
+        {% for message in messages %}
+        {% if messsage == "error" %}
+            <div class="notification {{ message.tags }}">
+        {% endif %}
+        {{ message }}
+        </div>
+        {% endfor %}
+         </div>
+        {% endif %}
+        <p>Are you sure you want to delete account associated with {{ user.email }}?</p>
+        <p>This action cannot be undone.</p>
+        <p>To confirm, please enter your password:</p>
+        <input type="password" name="password" required>
+        <button type="submit" action="{% url 'delete_account' %}" method="post">
+            Delete Account
+        </button>
+        <a href="{% url 'home' %}">Cancel</a>
+</html>


### PR DESCRIPTION
This pull request does the following:

* Creates the delete account view, allowing users to delete their account
* Creates the accounts/delete_account/ page
* Creates the accounts/account_goodbye/ page
* Updates the documentation to reflect the functionality

To test:
* Create an account that you are fine deleting.
* Go to /accounts/delete_account while signed out. You should be redirected to the login page.
* Go to /accounts/delete_account while signed in. Give the incorrect password. An error message should show on the page saying the password was incorrect
* Go to /accounts/delete_account while signed in. Give the correct password. You should be logged out, and then redirected to the goodbye account page. Verify that you can no longer sign in, and that your account no longer exists.