### PR TITLE
Fix: Clean up duplicate CreateModel operations in migrations

### DIFF
--- a/apps/core/migrations/0020_alter_actionstable_action_id_usernotificationqueue_and_more.py
+++ b/apps/core/migrations/0020_alter_actionstable_action_id_usernotificationqueue_and_more.py
@@ -92,42 +92,42 @@ class Migration(migrations.Migration):
                 "unique_together": {("action_id", "bill_id")},
             },
         ),
-        migrations.CreateModel(
-            name="UpdatesTable",
-            fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                ("description", models.CharField()),
-                ("date", models.DateTimeField()),
-                ("category", models.CharField(null=True)),
-                ("chamber", models.CharField()),
-                (
-                    "action_id",
-                    models.ForeignKey(
-                        db_column="action_id",
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="core.actionstable",
-                    ),
-                ),
-                (
-                    "bill_id",
-                    models.ForeignKey(
-                        db_column="bill_id",
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="core.billstable",
-                    ),
-                ),
-            ],
-            options={
-                "db_table": "updates_table",
-                "unique_together": {("action_id", "bill_id")},
-            },
-        ),
+        # migrations.CreateModel(
+        #     name="UpdatesTable",
+        #     fields=[
+        #         (
+        #             "id",
+        #             models.BigAutoField(
+        #                 auto_created=True,
+        #                 primary_key=True,
+        #                 serialize=False,
+        #                 verbose_name="ID",
+        #             ),
+        #         ),
+        #         ("description", models.CharField()),
+        #         ("date", models.DateTimeField()),
+        #         ("category", models.CharField(null=True)),
+        #         ("chamber", models.CharField()),
+        #         (
+        #             "action_id",
+        #             models.ForeignKey(
+        #                 db_column="action_id",
+        #                 on_delete=django.db.models.deletion.CASCADE,
+        #                 to="core.actionstable",
+        #             ),
+        #         ),
+        #         (
+        #             "bill_id",
+        #             models.ForeignKey(
+        #                 db_column="bill_id",
+        #                 on_delete=django.db.models.deletion.CASCADE,
+        #                 to="core.billstable",
+        #             ),
+        #         ),
+        #     ],
+        #     options={
+        #         "db_table": "updates_table",
+        #         "unique_together": {("action_id", "bill_id")},
+        #     },
+        # ),
     ]

--- a/apps/core/migrations/0021_updatesmockdjango.py
+++ b/apps/core/migrations/0021_updatesmockdjango.py
@@ -11,42 +11,42 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.CreateModel(
-            name="UpdatesMockDjango",
-            fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                ("description", models.CharField()),
-                ("date", models.DateTimeField()),
-                ("category", models.CharField(null=True)),
-                ("chamber", models.CharField()),
-                (
-                    "action_id",
-                    models.ForeignKey(
-                        db_column="action_id",
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="core.actionsmockdjango",
-                    ),
-                ),
-                (
-                    "bill_id",
-                    models.ForeignKey(
-                        db_column="bill_id",
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="core.billsmockdjango",
-                    ),
-                ),
-            ],
-            options={
-                "db_table": "updates_mock",
-                "unique_together": {("action_id", "bill_id")},
-            },
-        ),
+        # migrations.CreateModel(
+        #     name="UpdatesMockDjango",
+        #     fields=[
+        #         (
+        #             "id",
+        #             models.BigAutoField(
+        #                 auto_created=True,
+        #                 primary_key=True,
+        #                 serialize=False,
+        #                 verbose_name="ID",
+        #             ),
+        #         ),
+        #         ("description", models.CharField()),
+        #         ("date", models.DateTimeField()),
+        #         ("category", models.CharField(null=True)),
+        #         ("chamber", models.CharField()),
+        #         (
+        #             "action_id",
+        #             models.ForeignKey(
+        #                 db_column="action_id",
+        #                 on_delete=django.db.models.deletion.CASCADE,
+        #                 to="core.actionsmockdjango",
+        #             ),
+        #         ),
+        #         (
+        #             "bill_id",
+        #             models.ForeignKey(
+        #                 db_column="bill_id",
+        #                 on_delete=django.db.models.deletion.CASCADE,
+        #                 to="core.billsmockdjango",
+        #             ),
+        #         ),
+        #     ],
+        #     options={
+        #         "db_table": "updates_mock",
+        #         "unique_together": {("action_id", "bill_id")},
+        #     },
+        # ),
     ]

--- a/apps/core/migrations/0024_usernotificationqueue.py
+++ b/apps/core/migrations/0024_usernotificationqueue.py
@@ -39,6 +39,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 "db_table": "user_notification_queue",
+                "managed": False,
             },
         ),
     ]

--- a/apps/core/migrations/0030_mostrecentupload.py
+++ b/apps/core/migrations/0030_mostrecentupload.py
@@ -26,6 +26,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 "db_table": "most_recent_upload",
+                "managed": False,
             },
         ),
     ]


### PR DESCRIPTION
This PR does the following things:

* Fixes duplicate creation statements for the updates table, the mock users table, the user notification queue, and the most recent upload table
* Updated create model operations in the migration files with 'managed = False` to avoid re-creating existing tables in the future