### PR TITLE
206 edit bill page to not be state specific

### DIFF
--- a/apps/core/states.py
+++ b/apps/core/states.py
@@ -3,8 +3,9 @@ STATES = [
     ("IN", "Indiana"),
 ]
 
-STATE_NAME_TO_ABBR = {"Illinois": "IL",
-                      "Indiana": "IN"}
+STATE_NAME_TO_ABBR = {"Illinois": "IL", "Indiana": "IN"}
 
-STATE_LINKS = {"Illinois": "https://www.aclu-il.org/sites/default/files/how_a_bill_becomes_a_law_one_pager.pdf",
-               "Indiana": "https://www.in.gov/gov/files/BillintoLaw.pdf"}
+STATE_LINKS = {
+    "Illinois": "https://www.aclu-il.org/sites/default/files/how_a_bill_becomes_a_law_one_pager.pdf",
+    "Indiana": "https://www.in.gov/gov/files/BillintoLaw.pdf",
+}

--- a/apps/core/states.py
+++ b/apps/core/states.py
@@ -2,3 +2,9 @@ STATES = [
     ("IL", "Illinois"),
     ("IN", "Indiana"),
 ]
+
+STATE_NAME_TO_ABBR = {"Illinois": "IL",
+                      "Indiana": "IN"}
+
+STATE_LINKS = {"Illinois": "https://www.aclu-il.org/sites/default/files/how_a_bill_becomes_a_law_one_pager.pdf",
+               "Indiana": "https://www.in.gov/gov/files/BillintoLaw.pdf"}

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -12,7 +12,7 @@ from django.template.loader import render_to_string
 
 from .models import ActionsTable, BillsTable, FavoritesTable
 from .utils import bill_number_for_url, normalize_bill_number
-from .states import STATES
+from .states import STATES, STATE_NAME_TO_ABBR, STATE_LINKS
 
 
 def home(request: HttpRequest) -> HttpResponse:
@@ -220,6 +220,9 @@ def bill_page(
         "number": bill.number,
         "title": bill.title,
         "summary": bill.summary,
+        "state": bill.state,
+        "state_abbr": STATE_NAME_TO_ABBR[bill.state],
+        "state_link": STATE_LINKS[bill.state],
         "sponsors": [
             {
                 "sponsor_id": s.sponsor_id,
@@ -240,9 +243,9 @@ def bill_page(
         ],
     }
 
+
     return render(request, "bill_page.html", {"bill_data": data,
-                                              "states": STATES,
-                                              "state": state})
+                                              "states": STATES})
 
 
 @login_required

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -243,9 +243,7 @@ def bill_page(
         ],
     }
 
-
-    return render(request, "bill_page.html", {"bill_data": data,
-                                              "states": STATES})
+    return render(request, "bill_page.html", {"bill_data": data, "states": STATES})
 
 
 @login_required

--- a/templates/bill_page.html
+++ b/templates/bill_page.html
@@ -93,7 +93,7 @@
       <div class="columns">
         <div class="box column is-three-quarters-desktop">
           <h1 class="title is-4 custom-text-dark">
-            {{bill_data.number}} — {{bill_data.title}}
+            {{bill_data.state_abbr}} {{bill_data.number}} — {{bill_data.title}}
           </h1>
         </div>
         <div class="column">
@@ -127,10 +127,12 @@
             >View a
             <a
               class="custom-blue"
-              href="https://www.aclu-il.org/sites/default/files/how_a_bill_becomes_a_law_one_pager.pdf"
+              target="_blank" 
+              rel="noopener noreferrer"
+              href={{bill_data.state_link}}
               >detailed flow chart</a
             >
-            for more information on how a bill becomes law in Illinois.</i
+            for more information on how a bill becomes law in {{ bill_data.state }}.</i
           >
         </p>
         <!-- Bill Sponsors -->


### PR DESCRIPTION
This adds a state abbreviation to the bill title box and allows for each bill page to have a unique bill process flowchart link. 