### PR TITLE
148 add sort to search and favorite results

### DIFF
--- a/static/js/datatable.js
+++ b/static/js/datatable.js
@@ -1,0 +1,6 @@
+new DataTable('#search', {
+    paging: false,
+    searching: false,
+    // prevent sorting in favorites column (because datatables doesn't allow sorting by icon)
+    columnDefs: [{ orderable: false, targets: -1 }] 
+  });

--- a/static/js/datatable.js
+++ b/static/js/datatable.js
@@ -1,6 +1,7 @@
 new DataTable('#search', {
     paging: false,
     searching: false,
+    info: false, //exclude showing 1 of x entries 
     // prevent sorting in favorites column (because datatables doesn't allow sorting by icon)
     columnDefs: [{ orderable: false, targets: -1 }] 
   });

--- a/templates/search.html
+++ b/templates/search.html
@@ -125,7 +125,7 @@
         <tbody>
           {% for bill in results %}
           <tr>
-            <td class="py-5 custom-text-dark">{{ bill.number }}</td>
+            <td class="py-5 custom-text-dark has-text-weight-semibold">{{ bill.number }}</td>
             <td class="has-text-centered py-5 custom-text-dark">
               <a href="/bill/{{bill.bill_id}}/">{{bill.title}}</a>
             </td>

--- a/templates/search.html
+++ b/templates/search.html
@@ -12,14 +12,14 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.0/css/all.min.css"
     />
-    <!-- Link to custom CSS -->
-    <link rel="stylesheet" href="../static/css/custom.css" />
-    <link rel="stylesheet" href="https://cdn.datatables.net/2.3.1/css/dataTables.dataTables.css" />
-
     <!-- DataTables Customization -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/1.0.3/css/bulma.min.css"/>
     <link rel = "stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
     <link rel = "stylesheet" href="https://cdn.datatables.net/2.3.1/css/dataTables.bulma.css"/>  
+
+    <!-- Link to custom CSS -->
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.3.1/css/dataTables.dataTables.css" />
+    <link rel="stylesheet" href="../static/css/custom.css" />
   </head>
   <body>
     <section class="section">

--- a/templates/search.html
+++ b/templates/search.html
@@ -14,7 +14,12 @@
     />
     <!-- Link to custom CSS -->
     <link rel="stylesheet" href="../static/css/custom.css" />
-    <script src="https://unpkg.com/htmx.org"></script>
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.3.1/css/dataTables.dataTables.css" />
+
+    <!-- DataTables Customization -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/1.0.3/css/bulma.min.css"/>
+    <link rel = "stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
+    <link rel = "stylesheet" href="https://cdn.datatables.net/2.3.1/css/dataTables.bulma.css"/>  
   </head>
   <body>
     <section class="section">
@@ -101,7 +106,7 @@
         {% if state %} Search results for "{{ query }}" in {{state}}. {% else %}
         Search results for "{{ query }}" in all states. {% endif %}
       </div>
-      <table class="table bg-light is-hoverable">
+      <table id="search" class="table bg-light is-hoverable">
         <thead>
           <tr>
             <th class="is-size-5 custom-text-dark">Bill Number</th>
@@ -147,7 +152,7 @@
           </tbody>
         </table>
       </section>
-      <section class="section">
+      <section class="section"> 
         <!-- Pagination controls -->
         <nav class="pagination is-centered is-rounded" role="navigation" aria-label="pagination">
           {% if results.has_previous %}
@@ -200,5 +205,17 @@
       </section>
     <!-- JS for burger menu -->
     <script src="../static/js/burger.js"></script>
+
+    <!-- JS for DataTable -->
+    {% if results %}
+    <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
+    <script src="https://cdn.datatables.net/2.3.1/js/dataTables.js"></script>
+    <script src="https://cdn.datatables.net/2.3.1/js/dataTables.bulma.js"></script>
+    <script src="../static/js/datatable.js"></script>
+    {% endif %}
+
+    <!-- HTMX Script -->
+    <script src="https://unpkg.com/htmx.org"></script>
+
   </body>
 </html>


### PR DESCRIPTION
Table Sorting for the search page! Uses DataTables. 

Two notes: 

- I think it could be helpful to sort by date. If we want to do that though, we need the search view to have a bill.date attribute. 
- I currently disabled sorting by the favorites column. DataTables doesn't do a great job recognizing icons, so it doesn't work. I have an idea for implementing, but want to keep it on a seperate branch in case I don't get to it in time or I can't get it working. 
