### PR TITLE
Add link to delete account in favorites page

### DIFF
--- a/templates/favorites.html
+++ b/templates/favorites.html
@@ -82,6 +82,8 @@
                 <div class="card-footer">
                   <a href="/accounts/password/change/" class="card-footer-item has-text-link">Edit Password</a>
                 </div>
+                <div class ="card-footer">
+                  <a href="/accounts/delete_account/" class="card-footer-item has-text-link">Delete Account</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This pull request adds a link to the favorites page to delete account.

To test:
* Create an account that you don't care about deleting
* Go to the favorites page
* Delete your account through the delete account button